### PR TITLE
add a tool automaticly monitor file change and copy to a test dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,8 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# Editor Config
+.vscode/
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ $ pip install git+https://github.com/megemini/convert_doctest@main
 
 ## 使用方法
 
+首先使用 `convert-doctest` 将旧格式转换为新格式：
+
 ```shell
 $ convert-doctest source_file.py target_file.py
 ```
@@ -33,6 +35,18 @@ $ convert-doctest source_file.py
 ```
 
 `source_file.py` 和 `target_file.py` 是脚本转换的示例～
+
+之后运行 `watch-docstring` 监控该文件的修改（修改源文件，生成的文件会自动更新）
+
+```bash
+$ watch-docstring target_file.py
+```
+
+此时如果你修改文件的话，会生成一个 `xdoctest_test` 目录，里面包含了全部提取得到的 docstring，此时你只需要新开一个终端运行如下命令即可测试全部示例代码
+
+```bash
+$ xdoctest --global-exec "import paddle\npaddle.device.set_device('cpu')" xdoctest_test
+```
 
 ## 注意事项
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,11 @@ description = "a script for convert doctest"
 readme = "README.md"
 requires-python = ">=3.8,<3.11"
 license = { file = "LICENSE" }
+dependencies = ["watchdog"]
 
 [project.scripts]
 convert-doctest = "copy_preprocess:main"
+watch-docstring = "watch_docstring:main"
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/src/watch_docstring.py
+++ b/src/watch_docstring.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import argparse
 import ast
 import sys
 import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Iterable
+from typing import Hashable, Iterable
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
@@ -14,7 +15,7 @@ from watchdog.observers import Observer
 XDOCTEST_TEST_DIR = Path("./xdoctest_test")
 
 
-@dataclass
+@dataclass(frozen=True)
 class Location:
     lineno: int
     col_offset: int
@@ -44,18 +45,27 @@ class DocstringType(Enum):
             raise ValueError(f"Unknown node type {node_type}")
 
 
-@dataclass
+def hash_hex(value: Hashable) -> str:
+    return hex(hash(value) & 0xFFFFFFFF)[2:]
+
+
+def make_relative_path(path: Path) -> Path:
+    return path.relative_to(Path(".").absolute())
+
+
+@dataclass(frozen=True)
 class Docstring:
     type: DocstringType
     name: str
     source: str
+    path: Path
     start: Location
     end: Location
     raw_value: str
     value: str
 
 
-def extract_docstrings(source: str) -> Iterable[Docstring]:
+def extract_docstrings(source: str, source_path: Path) -> Iterable[Docstring]:
     tree = ast.parse(source)
 
     for node in ast.walk(tree):
@@ -81,6 +91,7 @@ def extract_docstrings(source: str) -> Iterable[Docstring]:
                     type=docstring_type,
                     name=docstring_name,
                     source=source,
+                    path=source_path,
                     start=start,
                     end=end,
                     raw_value=docstring_raw_value,
@@ -88,23 +99,67 @@ def extract_docstrings(source: str) -> Iterable[Docstring]:
                 )
 
 
+def clean_dir(path: Path):
+    for child in path.iterdir():
+        if child.is_dir():
+            clean_dir(child)
+            child.rmdir()
+        else:
+            child.unlink()
+
+
 def create_xdoctest_test_dir():
+    print("[Create] Create xdoctest_test dir")
     XDOCTEST_TEST_DIR.mkdir(exist_ok=True)
     gitignore_path = XDOCTEST_TEST_DIR / ".gitignore"
     gitignore_path.write_text("*\n")
+    fake_module_init_path = XDOCTEST_TEST_DIR / "__init__.py"
+    fake_module_init_path.write_text("\n")
+
+
+def clean_xdoctest_test_dir():
+    print("[Clean] Clean xdoctest_test dir")
+
+    clean_dir(XDOCTEST_TEST_DIR)
 
 
 def copy_docstring_to_xdoctest_test_dir(path: Path):
     template = """
 def test_{name}():
     {docstring}
+    code_src = "{path}"
+    code_src_with_lineno_and_offset = "{path}:{start.lineno}:{start.col_offset}"
 """
     content = path.read_text()
-    for docstring in extract_docstrings(content):
-        test_path = XDOCTEST_TEST_DIR / f"docstring_{docstring.name}.py"
-        test_path.write_text(
-            template.format(name=docstring.name, docstring=docstring.raw_value)
+    for docstring in extract_docstrings(content, source_path=path):
+        docstring_hash = hash_hex(docstring)
+        source_path_hash = hash_hex(str(docstring.path))
+        test_path = (
+            XDOCTEST_TEST_DIR
+            / f"{source_path_hash}"
+            / f"docstring_{docstring.name}_{docstring_hash}.py"
         )
+        test_path.parent.mkdir(exist_ok=True)
+        test_path_fake_init = test_path.parent / "__init__.py"
+        test_path_fake_init.write_text("\n")
+        test_path.write_text(
+            template.format(
+                name=docstring.name,
+                docstring=docstring.raw_value,
+                path=docstring.path,
+                start=docstring.start,
+            )
+        )
+
+
+def copy_docstring_recursive(path: Path):
+    print(f"[FirstCopy] Copy docstring from {path}")
+    if path.is_dir():
+        for child in path.iterdir():
+            copy_docstring_recursive(child)
+    else:
+        if path.suffix == ".py":
+            copy_docstring_to_xdoctest_test_dir(path)
 
 
 class Handler(FileSystemEventHandler):
@@ -114,13 +169,29 @@ class Handler(FileSystemEventHandler):
             return None
 
         elif event.event_type == "created":
-            print(f"[Create] {event.src_path}")
             if event.src_path.endswith(".py"):
-                copy_docstring_to_xdoctest_test_dir(Path(event.src_path))
+                print(f"[Create] {event.src_path}")
+                src_path = make_relative_path(Path(event.src_path))
+                copy_docstring_to_xdoctest_test_dir(src_path)
         elif event.event_type == "modified":
-            print(f"[Modify] {event.src_path}")
             if event.src_path.endswith(".py"):
-                copy_docstring_to_xdoctest_test_dir(Path(event.src_path))
+                print(f"[Modify] {event.src_path}")
+                src_path = make_relative_path(Path(event.src_path))
+                source_path_hash = hash_hex(str(src_path))
+                source_test_dir = XDOCTEST_TEST_DIR / source_path_hash
+                if source_test_dir.exists():
+                    clean_dir(source_test_dir)
+                    source_test_dir.rmdir()
+                copy_docstring_to_xdoctest_test_dir(src_path)
+        elif event.event_type == "deleted":
+            if event.src_path.endswith(".py"):
+                print(f"[Delete] {event.src_path}")
+                src_path = make_relative_path(Path(event.src_path))
+                source_path_hash = hash_hex(str(src_path))
+                source_test_dir = XDOCTEST_TEST_DIR / source_path_hash
+                if source_test_dir.exists():
+                    clean_dir(source_test_dir)
+                    source_test_dir.rmdir()
         else:
             print(f"Unsupport event: {event.event_type}")
 
@@ -128,17 +199,29 @@ class Handler(FileSystemEventHandler):
 def main():
     create_xdoctest_test_dir()
 
-    path = sys.argv[1]
-    observer = Observer()
-    event_handler = Handler()
-    observer.schedule(event_handler, path, recursive=True)
-    observer.start()
+    parser = argparse.ArgumentParser("watch_docstring")
+    parser.add_argument("watch_path", nargs="+")
+    args = parser.parse_args()
+    watch_paths = [Path(path) for path in args.watch_path]
+    observers = []
+    for path in watch_paths:
+        copy_docstring_recursive(path)
+        observer = Observer()
+        event_handler = Handler()
+        observer.schedule(event_handler, path, recursive=True)
+        observers.append(observer)
+        observer.start()
     try:
         while True:
             time.sleep(1)
+    except KeyboardInterrupt:
+        print("[Stop] Stop watch")
     finally:
-        observer.stop()
-        observer.join()
+        for observer in observers:
+            observer.stop()
+        for observer in observers:
+            observer.join()
+        clean_xdoctest_test_dir()
 
 
 if __name__ == "__main__":

--- a/src/watch_docstring.py
+++ b/src/watch_docstring.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import ast
+import sys
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Iterable
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+XDOCTEST_TEST_DIR = Path("./xdoctest_test")
+
+
+@dataclass
+class Location:
+    lineno: int
+    col_offset: int
+
+
+def crop_string(text: str, start: Location, end: Location) -> str:
+    lines_length = [len(line) + 1 for line in text.splitlines()]
+    start_index = sum(lines_length[: start.lineno - 1]) + start.col_offset
+    end_index = sum(lines_length[: end.lineno - 1]) + end.col_offset
+    return text[start_index:end_index]
+
+
+class DocstringType(Enum):
+    MODULE = "Module"
+    CLASS = "Class"
+    FUNCTION = "Function/Method"
+
+    @staticmethod
+    def from_node_type(node_type: type[ast.AST]) -> DocstringType:
+        if node_type == ast.Module:
+            return DocstringType.MODULE
+        elif node_type == ast.ClassDef:
+            return DocstringType.CLASS
+        elif node_type == ast.FunctionDef:
+            return DocstringType.FUNCTION
+        else:
+            raise ValueError(f"Unknown node type {node_type}")
+
+
+@dataclass
+class Docstring:
+    type: DocstringType
+    name: str
+    source: str
+    start: Location
+    end: Location
+    raw_value: str
+    value: str
+
+
+def extract_docstrings(source: str) -> Iterable[Docstring]:
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef)):
+            docstring_value = ast.get_docstring(node)
+            docstring_type = DocstringType.from_node_type(type(node))
+            docstring_name = node.name if not isinstance(node, ast.Module) else "<Mod>"
+            if docstring_value is None:
+                continue
+            if (
+                node.body
+                and isinstance(
+                    node.body[0], ast.Expr
+                )  # docstring is the first statement
+                and isinstance(node.body[0].value, ast.Constant)
+                and isinstance(node.body[0].value.value, str)
+            ):
+                docstring_node = node.body[0].value
+                start = Location(docstring_node.lineno, docstring_node.col_offset)
+                end = Location(docstring_node.end_lineno, docstring_node.end_col_offset)  # type: ignore
+                docstring_raw_value = crop_string(source, start, end)
+                yield Docstring(
+                    type=docstring_type,
+                    name=docstring_name,
+                    source=source,
+                    start=start,
+                    end=end,
+                    raw_value=docstring_raw_value,
+                    value=docstring_value,
+                )
+
+
+def create_xdoctest_test_dir():
+    XDOCTEST_TEST_DIR.mkdir(exist_ok=True)
+    gitignore_path = XDOCTEST_TEST_DIR / ".gitignore"
+    gitignore_path.write_text("*\n")
+
+
+def copy_docstring_to_xdoctest_test_dir(path: Path):
+    template = """
+def test_{name}():
+    {docstring}
+"""
+    content = path.read_text()
+    for docstring in extract_docstrings(content):
+        test_path = XDOCTEST_TEST_DIR / f"docstring_{docstring.name}.py"
+        test_path.write_text(
+            template.format(name=docstring.name, docstring=docstring.raw_value)
+        )
+
+
+class Handler(FileSystemEventHandler):
+    @staticmethod
+    def on_any_event(event):
+        if event.is_directory:
+            return None
+
+        elif event.event_type == "created":
+            print(f"[Create] {event.src_path}")
+            if event.src_path.endswith(".py"):
+                copy_docstring_to_xdoctest_test_dir(Path(event.src_path))
+        elif event.event_type == "modified":
+            print(f"[Modify] {event.src_path}")
+            if event.src_path.endswith(".py"):
+                copy_docstring_to_xdoctest_test_dir(Path(event.src_path))
+        else:
+            print(f"Unsupport event: {event.event_type}")
+
+
+def main():
+    create_xdoctest_test_dir()
+
+    path = sys.argv[1]
+    observer = Observer()
+    event_handler = Handler()
+    observer.schedule(event_handler, path, recursive=True)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1)
+    finally:
+        observer.stop()
+        observer.join()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
临时写了一个工具，用于监控一个文件的修改，并将其中的 docstring copy 到独立的目录，这样就可以直接 xdoctest 测试了

比如

```bash
convert-doctest python/paddle/jit/dy2static/program_translator.py
watch-docstring python/paddle/jit/dy2static/program_translator.py
# 之后修改 python/paddle/jit/dy2static/program_translator.py，docstring 会被自动 copy 到 xdoctest_test 下，每次修改都会自动更新

# 之后新开一个终端，直接执行 xdoctest
xdoctest --global-exec "import paddle\npaddle.device.set_device('cpu')" xdoctest_test
```

临时写的初版，主体代码 copy 自之前写的其他项目，还有很多问题～

TODOs:

- [x] 自动 clean 该 dir
- [x] 支持监控多个文件
- [x] 更好的源文件报错定位，更好的文件、函数命名
- [x] 首次 copy 不需要 modify 触发
- [ ] 等等

@megemini